### PR TITLE
- Add "skip_cleanup" in travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ after_success:
 - codecov
 before_deploy: yarn postversion
 deploy:
+  skip_cleanup: true
   provider: npm
   email: joe.grund@intel.com
   api_key:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iml/srcmap-reverse",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Reverses a minified stack trace using a source map.",
   "main": "dist/srcmap-reverse.js",
   "scripts": {


### PR DESCRIPTION
  - Add "skip_cleanup" to deploy to prevent travis from resetting the working directory during the deploy.

See https://docs.travis-ci.com/user/deployment/#Uploading-Files

Signed-off-by: Will Johnson <william.c.johnson@intel.com>