### PR TITLE
GH-49 Look for main.js.map in /usr/lib

### DIFF
--- a/source/reverser.js
+++ b/source/reverser.js
@@ -12,7 +12,7 @@ import highland from 'highland';
 import type { HighlandStreamT } from 'highland';
 
 export default (srcmapFile: ?string) => (s: HighlandStreamT<string>) => {
-  srcmapFile = srcmapFile || 'main.js.map';
+  srcmapFile = srcmapFile || '/usr/lib/main.js.map';
 
   const sourceMapStream = highland(createReadStream(srcmapFile));
 


### PR DESCRIPTION
Currently, we are looking for main.js.map in the executing directory. We
should instead look for this file in /usr/lib.

Signed-off-by: Will Johnson <william.c.johnson@intel.com>