### PR TITLE
GH-52 Remove GUI as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iml/srcmap-reverse",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "Reverses a minified stack trace using a source map.",
   "main": "dist/srcmap-reverse.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "flow": "flow",
     "eslint": "eslint ./",
     "rollup": "rollup -c rollup-config.js -i source/index.js -o $npm_package_main",
-    "postversion": "rm -rf ./dist; yarn rollup; cp node_modules/@iml/gui/dist/main.*.js.map dist/main.js.map"
+    "postversion": "rm -rf ./dist; yarn rollup"
   },
   "publishConfig": {
     "access": "public"
@@ -25,7 +25,6 @@
   "devDependencies": {
     "@iml/flow-highland": "4.2.8",
     "@iml/flow-jasmine": "1.6.1",
-    "@iml/gui": "6.0.13",
     "babel-eslint": "7.2.3",
     "babel-plugin-external-helpers": "6.22.0",
     "babel-plugin-transform-flow-strip-types": "6.22.0",
@@ -37,6 +36,7 @@
     "eslint-plugin-import": "^2.7.0",
     "eslint-plugin-prettier": "^2.1.2",
     "flow-bin": "0.50.0",
+    "glob": "7.1.2",
     "highland": "3.0.0-beta.4",
     "jest": "^20.0.4",
     "lerna": "^2.0.0",

--- a/source/reverser.js
+++ b/source/reverser.js
@@ -8,12 +8,13 @@
 import { createReadStream } from 'fs';
 import srcmapReverse from './srcmap-reverse.js';
 import highland from 'highland';
+import glob from 'glob';
 
 import type { HighlandStreamT } from 'highland';
 
 export default (srcmapFile: ?string) => (s: HighlandStreamT<string>) => {
-  srcmapFile = srcmapFile || '/usr/lib/main.js.map';
-
+  srcmapFile =
+    srcmapFile || glob.sync('/usr/lib/iml-manager/iml-gui/main.*.js.map')[0];
   const sourceMapStream = highland(createReadStream(srcmapFile));
 
   return highland([sourceMapStream, s])

--- a/test/reverser.test.js
+++ b/test/reverser.test.js
@@ -8,9 +8,9 @@ const reversedLine =
   'at /Users/wkseymou/projects/chroma/chroma-manager/chroma_ui_new/source/chroma_ui/iml/dashboard/dashboard-filter-controller.js:161:14';
 
 describe('reverser', () => {
-  let mockSrcMapReverse, mockFs, sourceMapStream, reverser, spy;
+  let mockSrcMapReverse, mockFs, sourceMapStream, reverser, mockGlob, spy;
 
-  beforeEach(done => {
+  beforeEach(() => {
     spy = jest.fn(() => 'spy');
     mockSrcMapReverse = jest.fn(() => reversedLine);
     jest.mock('../source/srcmap-reverse.js', () => mockSrcMapReverse);
@@ -24,33 +24,68 @@ describe('reverser', () => {
     };
     jest.mock('fs', () => mockFs);
 
-    reverser = require('../source/reverser.js').default;
+    mockGlob = {
+      sync: jest.fn(() => ['/usr/lib/iml-manager/iml-gui/main.fc123.js.map'])
+    };
+    jest.mock('glob', () => mockGlob);
 
-    reverser('test/fixtures/built-fd5ce21b.js.map.json')(
-      highland([
+    reverser = require('../source/reverser.js').default;
+  });
+
+  describe('with a sourcmap file specified', () => {
+    beforeEach(done => {
+      reverser('test/fixtures/built-fd5ce21b.js.map.json')(
+        highland([
+          'at Object.DashboardFilterCtrl.$scope.filter.onFilterView (https://localhost:8000/static/chroma_ui/built-fd5ce21b.js:38:7096)'
+        ])
+      ).each(x => {
+        spy(x);
+        done();
+      });
+    });
+
+    it('should call createReadStream', () => {
+      const sourceMapPath: string = mockFs.createReadStream.mock.calls[0][0];
+      expect(
+        sourceMapPath.indexOf('test/fixtures/built-fd5ce21b.js.map.json')
+      ).toBeGreaterThan(-1);
+    });
+
+    it('should call srcmapReverse', () => {
+      expect(mockSrcMapReverse).toHaveBeenCalledWith(
+        'source-maps',
         'at Object.DashboardFilterCtrl.$scope.filter.onFilterView (https://localhost:8000/static/chroma_ui/built-fd5ce21b.js:38:7096)'
-      ])
-    ).each(x => {
-      spy(x);
-      done();
+      );
+    });
+
+    it('should return the reversed line', () => {
+      expect(spy).toHaveBeenCalledWith(reversedLine);
     });
   });
 
-  it('should call createReadStream', () => {
-    const sourceMapPath: string = mockFs.createReadStream.mock.calls[0][0];
-    expect(
-      sourceMapPath.indexOf('test/fixtures/built-fd5ce21b.js.map.json')
-    ).toBeGreaterThan(-1);
-  });
+  describe('without a sourcemap file specified', () => {
+    beforeEach(done => {
+      reverser()(
+        highland([
+          'at Object.DashboardFilterCtrl.$scope.filter.onFilterView (https://localhost:8000/static/chroma_ui/built-fd5ce21b.js:38:7096)'
+        ])
+      ).each(x => {
+        spy(x);
+        done();
+      });
+    });
 
-  it('should call srcmapReverse', () => {
-    expect(mockSrcMapReverse).toHaveBeenCalledWith(
-      'source-maps',
-      'at Object.DashboardFilterCtrl.$scope.filter.onFilterView (https://localhost:8000/static/chroma_ui/built-fd5ce21b.js:38:7096)'
-    );
-  });
+    it('should call glob.sync', () => {
+      expect(mockGlob.sync).toHaveBeenCalledWith(
+        '/usr/lib/iml-manager/iml-gui/main.*.js.map'
+      );
+    });
 
-  it('should return the reversed line', () => {
-    expect(spy).toHaveBeenCalledWith(reversedLine);
+    it('should call createReadStream', () => {
+      const sourceMapPath: string = mockFs.createReadStream.mock.calls[0][0];
+      expect(
+        sourceMapPath.indexOf('/usr/lib/iml-manager/iml-gui/main.fc123.js.map')
+      ).toBeGreaterThan(-1);
+    });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,10 +10,6 @@
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/@iml/flow-jasmine/-/flow-jasmine-1.6.1.tgz#1b832db180087ebf05ad8ac9219d07718e05a334"
 
-"@iml/gui@6.0.13":
-  version "6.0.13"
-  resolved "https://registry.yarnpkg.com/@iml/gui/-/gui-6.0.13.tgz#e4a982a5a310cda0acff0ae1ab47456a7a76114f"
-
 JSONStream@^1.0.4:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.1.tgz#707f761e01dae9e16f1bcf93703b78c70966579a"
@@ -1770,7 +1766,7 @@ glob-parent@^2.0.0:
   dependencies:
     is-glob "^2.0.0"
 
-glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2:
+glob@7.1.2, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
   dependencies:


### PR DESCRIPTION
Fixes #52.

We've decided to package GUI into its own RPM. This means we no longer
need to include GUI as a dependency in srcmapreverse.

Signed-off-by: Will Johnson <william.c.johnson@intel.com>