### PR TITLE
Add Error Messages To Reverse Trace

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iml/srcmap-reverse",
-  "version": "3.0.6",
+  "version": "3.0.7",
   "description": "Reverses a minified stack trace using a source map.",
   "main": "dist/srcmap-reverse.js",
   "scripts": {

--- a/source/build-trace-collection.js
+++ b/source/build-trace-collection.js
@@ -5,7 +5,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-const traceItemRegex = /(http.+):(\d+):(\d+)/;
+export const traceItemRegex = /(http.+):(\d+):(\d+)/;
 
 import type { LineData } from './srcmap-reverse.js';
 

--- a/source/index.js
+++ b/source/index.js
@@ -42,16 +42,8 @@ if (cluster.isMaster) {
         .errors((e: Error) => {
           if (process.send) process.send({ error: e });
         })
-        .each((newLine: string[]) => {
-          if (!process.send) return;
-
-          let lineToSend;
-          if (newLine.length === 0) lineToSend = [];
-          else if (newLine[0].length === 0 && line && line.length > 0)
-            lineToSend = [line];
-          else lineToSend = newLine;
-
-          process.send({ line: lineToSend });
+        .each((line: string[]) => {
+          if (process.send) process.send({ line });
         });
     }
   );

--- a/source/index.js
+++ b/source/index.js
@@ -42,8 +42,16 @@ if (cluster.isMaster) {
         .errors((e: Error) => {
           if (process.send) process.send({ error: e });
         })
-        .each(line => {
-          if (process.send) process.send({ line });
+        .each((newLine: string[]) => {
+          if (!process.send) return;
+
+          let lineToSend;
+          if (newLine.length === 0) lineToSend = [];
+          else if (newLine[0].length === 0 && line && line.length > 0)
+            lineToSend = [line];
+          else lineToSend = newLine;
+
+          process.send({ line: lineToSend });
         });
     }
   );

--- a/source/srcmap-reverse.js
+++ b/source/srcmap-reverse.js
@@ -6,7 +6,10 @@
 // license that can be found in the LICENSE file.
 
 import { SourceMapConsumer } from 'source-map';
-import buildTraceCollection from './build-trace-collection.js';
+import {
+  default as buildTraceCollection,
+  traceItemRegex
+} from './build-trace-collection.js';
 
 export type LineData = {
   compiledLine: string,
@@ -23,6 +26,8 @@ type PositionData = {
 };
 
 export default (srcMap: string, trace: string) => {
+  if (!traceItemRegex.exec(trace)) return trace;
+
   const smc = new SourceMapConsumer(srcMap);
   return buildTraceCollection(trace)
     .map(smc.originalPositionFor.bind(smc))

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -185,8 +185,10 @@ at apply /Users/wkseymou/projects/chroma/chroma-manager/chroma_ui_new/source/chr
     });
 
     describe('with error message line', () => {
+      let errorMessage;
       beforeEach(() => {
-        mockReverser = jest.fn(() => () => highland(['']));
+        errorMessage = 'Error: Come on sourcemaps.';
+        mockReverser = jest.fn(() => () => highland([errorMessage]));
         jest.mock('../source/reverser.js', () => mockReverser);
 
         require('../source/index.js');
@@ -194,7 +196,7 @@ at apply /Users/wkseymou/projects/chroma/chroma-manager/chroma_ui_new/source/chr
         handler = process.on.mock.calls[0][1];
 
         handler({
-          line: 'Error: Come on sourcemaps.',
+          line: errorMessage,
           srcmapFile
         });
       });
@@ -212,7 +214,7 @@ at apply /Users/wkseymou/projects/chroma/chroma-manager/chroma_ui_new/source/chr
 
       it('should send the new line back to the master', () => {
         expect(process.send).toHaveBeenCalledWith({
-          line: ['Error: Come on sourcemaps.']
+          line: [errorMessage]
         });
       });
     });

--- a/test/srcmap-reverse.test.js
+++ b/test/srcmap-reverse.test.js
@@ -31,16 +31,18 @@ describe('src map reverse', () => {
     };
     jest.mock('source-map', () => mockSourceMapConsumer);
 
-    mockBuildTraceCollection = jest
-      .fn(() => 'buildTraceCollection')
-      .mockReturnValue([
-        {
-          compiledLine: 'compiledLine',
-          url: 'url',
-          line: 50,
-          column: 25
-        }
-      ]);
+    mockBuildTraceCollection = jest.fn(() => [
+      {
+        compiledLine: 'compiledLine',
+        url: 'url',
+        line: 50,
+        column: 25
+      }
+    ]);
+
+    // $FlowFixMe - traceItemRegex is indeed in buildTraceCollection
+    mockBuildTraceCollection.traceItemRegex = /(http.+):(\d+):(\d+)/;
+
     jest.mock(
       '../source/build-trace-collection.js',
       () => mockBuildTraceCollection

--- a/yarn.lock
+++ b/yarn.lock
@@ -33,7 +33,7 @@ acorn-jsx@^3.0.0:
   dependencies:
     acorn "^3.0.4"
 
-acorn@4.x, acorn@^4.0.1, acorn@^4.0.4:
+acorn@4.x, acorn@^4.0.4:
   version "4.0.13"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.13.tgz#105495ae5361d697bd195c825192e1ad7f253787"
 
@@ -41,7 +41,7 @@ acorn@^3.0.4:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
 
-acorn@^5.0.1:
+acorn@^5.0.1, acorn@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.1.1.tgz#53fe161111f912ab999ee887a90a0bc52822fd75"
 
@@ -615,12 +615,12 @@ babel-plugin-transform-flow-strip-types@6.22.0:
     babel-plugin-syntax-flow "^6.18.0"
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-object-rest-spread@6.23.0:
-  version "6.23.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.23.0.tgz#875d6bc9be761c58a2ae3feee5dc4895d8c7f921"
+babel-plugin-transform-object-rest-spread@6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz#0f36692d50fef6b7e2d4b3ac1478137a963b7b06"
   dependencies:
     babel-plugin-syntax-object-rest-spread "^6.8.0"
-    babel-runtime "^6.22.0"
+    babel-runtime "^6.26.0"
 
 babel-plugin-transform-regenerator@^6.22.0:
   version "6.24.1"
@@ -694,6 +694,13 @@ babel-runtime@^6.18.0, babel-runtime@^6.22.0:
   dependencies:
     core-js "^2.4.0"
     regenerator-runtime "^0.10.0"
+
+babel-runtime@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
+  dependencies:
+    core-js "^2.4.0"
+    regenerator-runtime "^0.11.0"
 
 babel-template@^6.16.0, babel-template@^6.24.1, babel-template@^6.25.0:
   version "6.25.0"
@@ -1468,6 +1475,10 @@ estree-walker@^0.2.1:
 estree-walker@^0.3.0:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.3.1.tgz#e6b1a51cf7292524e7237c312e5fe6660c1ce1aa"
+
+estree-walker@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.5.0.tgz#aae3b57c42deb8010e349c892462f0e71c5dd1aa"
 
 esutils@^2.0.2:
   version "2.0.2"
@@ -2645,9 +2656,9 @@ magic-string@*:
   dependencies:
     vlq "^0.2.1"
 
-magic-string@^0.19.0:
-  version "0.19.1"
-  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.19.1.tgz#14d768013caf2ec8fdea16a49af82fc377e75201"
+magic-string@^0.22.4:
+  version "0.22.4"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.22.4.tgz#31039b4e40366395618c1d6cf8193c53917475ff"
   dependencies:
     vlq "^0.2.1"
 
@@ -3132,6 +3143,10 @@ regenerator-runtime@^0.10.0:
   version "0.10.5"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz#336c3efc1220adcedda2c9fab67b5a7955a33658"
 
+regenerator-runtime@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz#7e54fe5b5ccd5d6624ea6255c3473be090b802e1"
+
 regenerator-transform@0.9.11:
   version "0.9.11"
   resolved "https://registry.yarnpkg.com/regenerator-transform/-/regenerator-transform-0.9.11.tgz#3a7d067520cb7b7176769eb5ff868691befe1283"
@@ -3233,9 +3248,15 @@ resolve@1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
 
-resolve@^1.1.6, resolve@^1.1.7, resolve@^1.2.0, resolve@^1.3.2:
+resolve@^1.1.6, resolve@^1.2.0, resolve@^1.3.2:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.3.3.tgz#655907c3469a8680dc2de3a275a8fdd69691f0e5"
+  dependencies:
+    path-parse "^1.0.5"
+
+resolve@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.4.0.tgz#a75be01c53da25d934a98ebd0e4c4a7312f92a86"
   dependencies:
     path-parse "^1.0.5"
 
@@ -3275,14 +3296,14 @@ rollup-plugin-cleanup@1.0.1:
     magic-string "*"
     rollup-pluginutils "*"
 
-rollup-plugin-commonjs@8.0.2:
-  version "8.0.2"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-commonjs/-/rollup-plugin-commonjs-8.0.2.tgz#98b1589bfe32a6c0f67790b60c0b499972afed89"
+rollup-plugin-commonjs@8.1.1:
+  version "8.1.1"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-commonjs/-/rollup-plugin-commonjs-8.1.1.tgz#742a0a0c9de69941a6c3b95806a167071ef62c7a"
   dependencies:
-    acorn "^4.0.1"
-    estree-walker "^0.3.0"
-    magic-string "^0.19.0"
-    resolve "^1.1.7"
+    acorn "^5.1.1"
+    estree-walker "^0.5.0"
+    magic-string "^0.22.4"
+    resolve "^1.4.0"
     rollup-pluginutils "^2.0.1"
 
 rollup-plugin-node-resolve@3.0.0:
@@ -3308,11 +3329,9 @@ rollup-pluginutils@^1.5.0:
     estree-walker "^0.2.1"
     minimatch "^3.0.2"
 
-rollup@0.45.2:
-  version "0.45.2"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.45.2.tgz#63a284c2b31234656f24e9e9717fabb6a7f0fa43"
-  dependencies:
-    source-map-support "^0.4.0"
+rollup@0.46.0:
+  version "0.46.0"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.46.0.tgz#98b1cd282cbfaa0f823c339a5623b61d0f1bec2a"
 
 run-async@^2.2.0:
   version "2.3.0"
@@ -3406,7 +3425,7 @@ sort-keys@^2.0.0:
   dependencies:
     is-plain-obj "^1.0.0"
 
-source-map-support@^0.4.0, source-map-support@^0.4.2:
+source-map-support@^0.4.2:
   version "0.4.15"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.15.tgz#03202df65c06d2bd8c7ec2362a193056fef8d3b1"
   dependencies:


### PR DESCRIPTION
srcmap-reverse does not currently include the error message in the
  reverse trace. Make sure to include error messages, even with multiple
  lines, in the reversed trace so that the error message can be seen in
  the logs.

Signed-off-by: Will Johnson <william.c.johnson@intel.com>